### PR TITLE
Fix broken reference links in NextJS lesson

### DIFF
--- a/lessons/04-rscs-with-nextjs/A-abbreviated-intro-to-nextjs.md
+++ b/lessons/04-rscs-with-nextjs/A-abbreviated-intro-to-nextjs.md
@@ -104,6 +104,6 @@ Great! This should be all fairly non-interesting. The only thing here is that pa
 
 Lastly, update [the globals.css to be this][css]. Go ahead and delete page.module.css. CSS modules are awesome but not in scope for this class so I've just written all the CSS for you.
 
-[seed]:
-[db]:
-[css]:
+[seed]: https://github.com/btholt/irv6-project/blob/main/completed/nextjs/seed.sql
+[db]: https://github.com/btholt/irv6-project/blob/main/notes.db
+[css]: https://github.com/btholt/irv6-project/blob/main/globals.css


### PR DESCRIPTION
## Problem
The NextJS introduction lesson (04-A) contained three broken reference links at the bottom of the file. These links were defined but not populated with actual URLs, causing students to encounter dead links when trying to access the referenced resources.

## Changes Made
- ✅ Added GitHub URL for `[seed]` reference → `https://github.com/btholt/irv6-project/blob/main/completed/nextjs/seed.sql`
- ✅ Added GitHub URL for `[db]` reference → `https://github.com/btholt/irv6-project/blob/main/notes.db`
- ✅ Added GitHub URL for `[css]` reference → `https://github.com/btholt/irv6-project/blob/main/globals.css`

## Files Modified
- `lessons/04-rscs-with-nextjs/A-abbreviated-intro-to-nextjs.md`

## Testing
1. Navigate to the lesson file
2. Verify that all three reference links now point to valid GitHub URLs
3. Confirm that the linked resources are accessible

## Impact
- 🐛 Fixes broken links that were preventing students from accessing required resources
- 📚 Improves learning experience by providing direct access to seed data, database, and CSS files
- ✨ Maintains consistency with other lesson reference link patterns

Fixes #7 