### PR TITLE
Fix: Add missing "use client" directive in RSC limitations lesson example

### DIFF
--- a/lessons/04-rscs-with-nextjs/E-limitations-of-rscs.md
+++ b/lessons/04-rscs-with-nextjs/E-limitations-of-rscs.md
@@ -60,6 +60,7 @@ export default async function WhoAmI() {
 And now clientPage.js
 
 ```javascript
+"use client";
 import updateUsername from "./updateUsername";
 
 export default function ClientWhoAmIPage({ children, id }) {


### PR DESCRIPTION
Solves #9 

### 📝 Description
Adds the missing `"use client"` directive to the client component code example in lesson 04-E (Limitations of RSCs). This ensures the code example accurately demonstrates how to properly define a client component in Next.js.

### 🐛 Problem
The code example for `clientPage.js` in the RSC limitations lesson was missing the required `"use client"` directive, which could confuse learners about the proper syntax for client components in Next.js applications.

### ✅ Solution
- Added `"use client";` directive at the top of the clientPage.js code block
- Ensures educational accuracy and follows Next.js client component conventions

### 📋 Changes Made
- **File**: `lessons/04-rscs-with-nextjs/E-limitations-of-rscs.md`
- **Change**: Added `"use client";` directive to clientPage.js code example

### 📄 Code Diff
```diff
 ```javascript
+"use client";
 import updateUsername from "./updateUsername";
 
 export default function ClientWhoAmIPage({ children, id }) {
```